### PR TITLE
Renames package to @release-it-plugins/workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ folder and calling `npm publish`).
 Installation using your projects normal package manager, for example:
 
 ```sh
+npm install --save-dev @release-it/workspaces
+
+# or
+
 yarn add --dev --ignore-workspace-root-check @release-it-plugins/workspaces
 ```
 
@@ -62,7 +66,7 @@ A quick summary (in TypeScript syntax) of the supported options (more details
 on each just below):
 
 ```ts
-interface ReleaseItYarnWorkSpacesConfiguration {
+interface ReleaseItWorkSpacesConfiguration {
   /**
     Disables checks for `npm` registry and login info.
 
@@ -178,9 +182,9 @@ used.
 ### workspaces
 
 The list of workspaces is gathered from the `package.json` in the current
-working directory. This is the same location that `yarn install` uses, and it
+working directory. This is the same location that `npm install`/`yarn install` uses, and it
 is a great default for `@release-it-plugins/workspaces`. In some circumstances, the
-workspace settings that `yarn` should use differ from the actual locations that
+workspace settings that `npm`/`yarn` should use differ from the actual locations that
 are published.  Most commonly this is due to a custom build script that emits
 the compiled and ready to publish packages into a different location (e.g.
 `dist/packages/*`).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# release-it-yarn-workspaces
+# @release-it-plugins/workspaces
 
 This package is a [release-it](https://github.com/release-it/release-it) plugin
 (using [`release-it`'s plugin
@@ -19,10 +19,10 @@ folder and calling `npm publish`).
 Installation using your projects normal package manager, for example:
 
 ```sh
-yarn add --dev --ignore-workspace-root-check release-it-yarn-workspaces
+yarn add --dev --ignore-workspace-root-check @release-it-plugins/workspaces
 ```
 
-Once installed, configure `release-it` to use the plugin. 
+Once installed, configure `release-it` to use the plugin.
 
 For example, configuring via `package.json` would look like this:
 
@@ -30,7 +30,7 @@ For example, configuring via `package.json` would look like this:
 {
   "release-it": {
     "plugins": {
-      "release-it-yarn-workspaces": true
+      "@release-it-plugins/workspaces": true
     }
   }
 }
@@ -46,7 +46,7 @@ would add the following to your `release-it` config (again showing
 {
   "release-it": {
     "plugins": {
-      "release-it-yarn-workspaces": true
+      "@release-it-plugins/workspaces": true
     },
     "npm": false
   }
@@ -55,7 +55,7 @@ would add the following to your `release-it` config (again showing
 
 ## Configuration
 
-For the most part `release-it-yarn-workspaces` "does the right thing", but
+For the most part `@release-it-plugins/workspaces` "does the right thing", but
 there are a few things that are configurable.
 
 A quick summary (in TypeScript syntax) of the supported options (more details
@@ -115,7 +115,7 @@ interface ReleaseItYarnWorkSpacesConfiguration {
 
 ### skipChecks
 
-By default, `release-it-yarn-workspaces` confirms that the `npm` registry is up
+By default, `@release-it-plugins/workspaces` confirms that the `npm` registry is up
 and running (via `npm ping`) and that you are authenticated properly (via `npm
 whoami`). If you'd prefer to avoid these checks (e.g. your custom `npm`
 registry does not support them) you can specify the `skipChecks` option:
@@ -124,7 +124,7 @@ registry does not support them) you can specify the `skipChecks` option:
 {
   "release-it": {
     "plugins": {
-      "release-it-yarn-workspaces": {
+      "@release-it-plugins/workspaces": {
         "skipChecks": true
       }
     }
@@ -134,7 +134,7 @@ registry does not support them) you can specify the `skipChecks` option:
 
 ### publish
 
-`release-it-yarn-workspaces` publishes to the `npm` registry.
+`@release-it-plugins/workspaces` publishes to the `npm` registry.
 However, some repository configurations prefer to commit + tag then let CI
 publish the actual packages to the registry. This is where the `publish` option
 comes in:
@@ -143,7 +143,7 @@ comes in:
 {
   "release-it": {
     "plugins": {
-      "release-it-yarn-workspaces": {
+      "@release-it-plugins/workspaces": {
         "publish": false
       }
     }
@@ -157,7 +157,7 @@ published.
 
 ### distTag
 
-`release-it-yarn-workspaces` uses the `latest` dist-tag when the
+`@release-it-plugins/workspaces` uses the `latest` dist-tag when the
 released version is a stable release and the prereleaseId when it is a
 prerelease (e.g. `beta` for `1.0.0-beta.1`). This is a good default setup, but
 there may be cases where you would like to specify a custom dist-tag to be
@@ -167,7 +167,7 @@ used.
 {
   "release-it": {
     "plugins": {
-      "release-it-yarn-workspaces": {
+      "@release-it-plugins/workspaces": {
         "distTag": "lts"
       }
     }
@@ -179,7 +179,7 @@ used.
 
 The list of workspaces is gathered from the `package.json` in the current
 working directory. This is the same location that `yarn install` uses, and it
-is a great default for `release-it-yarn-workspaces`. In some circumstances, the
+is a great default for `@release-it-plugins/workspaces`. In some circumstances, the
 workspace settings that `yarn` should use differ from the actual locations that
 are published.  Most commonly this is due to a custom build script that emits
 the compiled and ready to publish packages into a different location (e.g.
@@ -189,7 +189,7 @@ the compiled and ready to publish packages into a different location (e.g.
 {
   "release-it": {
     "plugins": {
-      "release-it-yarn-workspaces": {
+      "@release-it-plugins/workspaces": {
         "workspaces": ["dist/packages/*"]
       }
     }
@@ -198,7 +198,7 @@ the compiled and ready to publish packages into a different location (e.g.
 ```
 
 This value replaces the value from `package.json`, and given the above
-configuration `release-it-yarn-workspaces` would publish each package (that was
+configuration `@release-it-plugins/workspaces` would publish each package (that was
 not private) in `dist/packages` folder.
 
 ### additionalManifests
@@ -213,7 +213,7 @@ you may publish an alternate `docs.json` file in your published package.
 {
   "release-it": {
     "plugins": {
-      "release-it-yarn-workspaces": {
+      "@release-it-plugins/workspaces": {
         "additionalManifests": {
           "versionUpdates": ["dist/docs.json"]
       }
@@ -239,7 +239,7 @@ newly published versions.
 {
   "release-it": {
     "plugins": {
-      "release-it-yarn-workspaces": {
+      "@release-it-plugins/workspaces": {
         "additionalManifests": {
           "dependencyUpdates": ["blueprints/*/package.json"]
       }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -47,7 +47,7 @@ npm install --global release-it
 * Second, ensure that you have installed your projects dependencies:
 
 ```
-yarn install
+npm install
 ```
 
 * And last (but not least 😁) do your release. It requires a

--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -4,7 +4,7 @@ import { createTempDir } from 'broccoli-test-helper';
 import { factory, runTasks } from 'release-it/test/util/index.js';
 import Plugin from '../index.js';
 
-const namespace = 'release-it-yarn-workspaces';
+const namespace = '@release-it-plugins/workspaces';
 
 class TestPlugin extends Plugin {
   constructor() {
@@ -116,7 +116,7 @@ function json(obj) {
   return JSON.stringify(obj, null, 2);
 }
 
-describe('release-it-yarn-workspaces', () => {
+describe('@release-it-plugins/workspaces', () => {
   let ROOT = process.cwd();
   let dir;
 

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ export default class YarnWorkspacesPlugin extends Plugin {
       publish: {
         type: 'confirm',
         message: (context) => {
-          const { distTag, packagesToPublish } = context['release-it-yarn-workspaces'];
+          const { distTag, packagesToPublish } = context['@release-it-plugins/workspaces'];
 
           return this._formatPublishMessage(distTag, packagesToPublish);
         },
@@ -143,7 +143,7 @@ export default class YarnWorkspacesPlugin extends Plugin {
       'publish-as-public': {
         type: 'confirm',
         message(context) {
-          const { currentPackage } = context['release-it-yarn-workspaces'];
+          const { currentPackage } = context['@release-it-plugins/workspaces'];
 
           return `Publishing ${currentPackage.name} failed because \`publishConfig.access\` is not set in its \`package.json\`.\n  Would you like to publish ${currentPackage.name} as a public package?`;
         },

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function resolveWorkspaces(workspaces) {
   }
 
   throw new Error(
-    "This package doesn't use yarn workspaces. (package.json doesn't contain a `workspaces` property)"
+    "This package doesn't use workspaces. (package.json doesn't contain a `workspaces` property)"
   );
 }
 
@@ -118,7 +118,7 @@ class JSONFile {
   }
 }
 
-export default class YarnWorkspacesPlugin extends Plugin {
+export default class WorkspacesPlugin extends Plugin {
   static isEnabled(options) {
     return fs.existsSync(ROOT_MANIFEST_PATH) && options !== false;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "release-it-yarn-workspaces",
+  "name": "@release-it-plugins/workspaces",
   "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "release-it-yarn-workspaces",
+      "name": "@release-it-plugins/workspaces",
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "node": ">= 14"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "release-it": {
     "plugins": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@release-it-plugins/workspaces",
   "version": "2.0.1",
-  "description": "release-it plugin for bumping and publishing yarn workspaces",
+  "description": "release-it plugin for bumping and publishing workspaces",
   "keywords": [
     "release",
     "release-it",
     "release-it-plugin",
     "plugin"
   ],
-  "repository": "https://github.com/rwjblue/@release-it-plugins/workspaces",
+  "repository": "https://github.com/@release-it-plugins/workspaces",
   "license": "MIT",
   "author": "Robert Jackson <me@rwjblue.com>",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "release-it-yarn-workspaces",
+  "name": "@release-it-plugins/workspaces",
   "version": "2.0.1",
   "description": "release-it plugin for bumping and publishing yarn workspaces",
   "keywords": [
@@ -8,7 +8,7 @@
     "release-it-plugin",
     "plugin"
   ],
-  "repository": "https://github.com/rwjblue/release-it-yarn-workspaces",
+  "repository": "https://github.com/rwjblue/@release-it-plugins/workspaces",
   "license": "MIT",
   "author": "Robert Jackson <me@rwjblue.com>",
   "type": "module",


### PR DESCRIPTION
Since this package doesn't have a hard dependency on yarn workspaces, we're renaming it to the more generic variant - `@release-it-plugins/workspaces`.

Addresses #69