### PR TITLE
Add `release-it@^15.0.0` (latest 15.x) to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        release-it-version: ["14.0.0", "14.1.0", "14.2.0", "15.2.0"]
+        release-it-version: ["14.0.0", "14.1.0", "14.2.0", "15.2.0", "^15.0.0"]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Previously, we were only testing against specific release-it@14 and release-it@15 versions. This ensures that we have "latest 15" under test also.
