### PR TITLE
Allow publishing from a specific folder using `publishPath` attribute

### DIFF
--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -260,6 +260,62 @@ describe('@release-it-plugins/workspaces', () => {
       expect(readWorkspacePackage('foo').version).toEqual('1.0.1');
     });
 
+    it('publishes from the publishPath attribute of the package.json', async () => {
+      setupProject({ packages: ['packages/*'] });
+
+      setupWorkspace({ name: 'foo' });
+      setupWorkspace({ name: 'bar', publishPath: 'dist' });
+
+      let plugin = buildPlugin();
+
+      await runTasks(plugin);
+
+      expect(plugin.operations).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "command": "npm ping --registry https://registry.npmjs.org",
+            "operationType": "command",
+            "options": undefined,
+          },
+          Object {
+            "command": "npm whoami --registry https://registry.npmjs.org",
+            "operationType": "command",
+            "options": undefined,
+          },
+          Object {
+            "command": "npm publish ./packages/bar/dist --tag latest",
+            "operationType": "command",
+            "options": Object {
+              "write": false,
+            },
+          },
+          Object {
+            "command": "npm publish ./packages/foo --tag latest",
+            "operationType": "command",
+            "options": Object {
+              "write": false,
+            },
+          },
+          Object {
+            "messages": Array [
+              "🔗 https://www.npmjs.com/package/bar",
+            ],
+            "operationType": "log",
+          },
+          Object {
+            "messages": Array [
+              "🔗 https://www.npmjs.com/package/foo",
+            ],
+            "operationType": "log",
+          },
+        ]
+      `);
+
+      expect(JSON.parse(dir.readText('package.json')).version).toEqual('1.0.1');
+      expect(readWorkspacePackage('bar').version).toEqual('1.0.1');
+      expect(readWorkspacePackage('foo').version).toEqual('1.0.1');
+    });
+
     it('updates dependencies / devDependencies of packages', async () => {
       setupWorkspace({ name: 'derp' });
       setupWorkspace({ name: 'qux' });

--- a/index.js
+++ b/index.js
@@ -534,7 +534,7 @@ export default class WorkspacesPlugin extends Plugin {
       let absolutePath = path.join(root, file);
       let pkgInfo = JSONFile.for(absolutePath);
 
-      let relativeRoot = path.dirname(file);
+      let relativeRoot = path.join(path.dirname(file), pkgInfo.pkg.publishPath || '');
 
       return {
         root: path.join(root, relativeRoot),


### PR DESCRIPTION
This is to allow publishing only a specific folder from within a package. In order to publish a specific folder, developers can add the following attribute to the relevant package's `package.json` file:

```json
"publishPath": "dist"
```

This will run the `npm publish` command from within the `dist` folder, allowing only the content of this directory to be published. 