### PR TITLE
Feature/new feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,6 +399,11 @@ export default class WorkspacesPlugin extends Plugin {
     }
   }
 
+  getPublicPath() {
+    const { publishConfig } = this.getContext();
+    return (publishConfig && publishConfig.publicPath) ?? '';
+  }
+
   getReleaseUrl(workspaceInfo) {
     const registry = this.getRegistry();
     const baseUrl = registry !== NPM_DEFAULT_REGISTRY ? registry : NPM_BASE_URL;

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ const DEFAULT_TAG = 'latest';
 const NPM_BASE_URL = 'https://www.npmjs.com';
 const NPM_DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 const DETECT_TRAILING_WHITESPACE = /\s+$/;
+const NPM_PUBLIC_PATH = '/package';
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -401,8 +402,9 @@ export default class WorkspacesPlugin extends Plugin {
   getReleaseUrl(workspaceInfo) {
     const registry = this.getRegistry();
     const baseUrl = registry !== NPM_DEFAULT_REGISTRY ? registry : NPM_BASE_URL;
+    const publicPath = this.getPublicPath() || NPM_PUBLIC_PATH;
 
-    return urlJoin(baseUrl, 'package', workspaceInfo.name);
+    return urlJoin(baseUrl, publicPath, workspaceInfo.name);
   }
 
   getRegistry() {


### PR DESCRIPTION
 Adding publicPath option for npm publishConfig.

In the `package.json`, we can custom like this
 
 `  "publishConfig": {
    "registry": "https://npm.baijia.com",
    "publicPath": "/-/web/detail"
  }`
  
  
  so when publish suceess ,we can get this `
! echo Successfully released 
🔗 https://npm.baijia.com/-/web/detail/@coeus/components
`