### PR TITLE
Fix dependency version support to allow any comparison operators (e.g. `>=`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -331,7 +331,6 @@ export default class WorkspacesPlugin extends Plugin {
 
   _buildReplacementDepencencyVersion(existingVersion, newVersion) {
     let prefix = '';
-    let firstChar = '';
     let range = existingVersion;
     let suffix = newVersion;
 
@@ -343,16 +342,13 @@ export default class WorkspacesPlugin extends Plugin {
       suffix = range.length > 1 ? newVersion : '';
     }
 
-    // preserve existing floating constraint
-    if (['^', '~'].includes(range[0])) {
-      firstChar = range[0];
-    }
-
+    // capture any leading characters up to the first digit
+    const operator = range.match(/^[^0-9]*/)[0];
     if ('*' === range) {
       return `${prefix}*`;
     }
 
-    return `${prefix}${firstChar}${suffix}`;
+    return `${prefix}${operator}${suffix}`;
   }
 
   _updateDependencies(pkgInfo, newVersion) {

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -1868,5 +1868,6 @@ describe('@release-it-plugins/workspaces', () => {
     updatesTo({ existing: 'workspace:^', new: '2.0.0', expected: 'workspace:^' });
     updatesTo({ existing: 'workspace:~', new: '2.0.0', expected: 'workspace:~' });
     updatesTo({ existing: 'workspace:*', new: '2.0.0', expected: 'workspace:*' });
+    updatesTo({ existing: '>=1.0.0', new: '1.0.1', expected: '>=1.0.1' });
   });
 });


### PR DESCRIPTION
- keep comparison operators when updating workspace dependencies
- test preserving `>=` prefix in `_buildReplacementDepencencyVersion`
- simplify operator detection logic

Fix #116 