### PR TITLE
Update npm lockfile after version bump

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,10 @@ function hasPnpm() {
   return fs.existsSync('./pnpm-lock.yaml') || fs.existsSync(PNPM_WORKSPACE_PATH);
 }
 
+function hasNpmLockfile() {
+  return fs.existsSync('./package-lock.json');
+}
+
 function resolveWorkspaces(workspaces) {
   if (Array.isArray(workspaces)) {
     return workspaces;
@@ -293,6 +297,8 @@ export default class WorkspacesPlugin extends Plugin {
        */
       if (hasPnpm()) {
         await this.exec(`pnpm install`);
+      } else if (hasNpmLockfile()) {
+        await this.exec(`npm install --package-lock-only`);
       }
     };
 

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -423,6 +423,25 @@ describe('@release-it-plugins/workspaces', () => {
       expect(readWorkspacePackage('foo').version).toEqual('1.0.1');
     });
 
+    it('updates npm lockfile when present', async () => {
+      dir.write({
+        'package-lock.json': json({
+          name: 'root',
+          version: '0.0.0',
+          lockfileVersion: 3,
+          packages: {},
+        }),
+      });
+
+      let plugin = await buildPlugin();
+
+      await runTasks(plugin);
+
+      expect(
+        plugin.commands.some((operation) => operation.command === 'npm install --package-lock-only')
+      ).toBe(true);
+    });
+
     it('updates dependencies / devDependencies of packages', async () => {
       setupWorkspace({ name: 'derp' });
       setupWorkspace({ name: 'qux' });


### PR DESCRIPTION
### Motivation
- Prevent the repository from ending up with a dirty `package-lock.json` after bumping versions when pnpm is not in use by ensuring the npm lockfile is refreshed.

### Description
- Add `hasNpmLockfile()` to detect a `package-lock.json` and run `npm install --package-lock-only` when `pnpm` is not detected to update the npm lockfile after version changes.

### Testing
- Ran `eslint` and the lint checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69681392e62c832583baa5fe7772483e)