### PR TITLE
Warn when release-it's built-in npm plugin is left enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,18 @@ For example, configuring via `package.json` would look like this:
 }
 ```
 
-Often times the root `package.json` for a workspace setup is commonly not
-published, in order to configure `release-it` to avoid attempting to publish
-the top level package (in addition to publishing your workspace packages), you
-would add the following to your `release-it` config (again showing
-`package.json` style configuration):
+This plugin fully replaces `release-it`'s built-in `npm` plugin (it handles
+both version bumping and publishing for each workspace). You should therefore
+disable the built-in `npm` plugin by setting `npm` to `false`. If you leave it
+enabled, `release-it` will _also_ run `npm version` and attempt to `npm publish`
+the root `package.json`, which conflicts with this plugin and produces confusing
+errors. The plugin will emit a warning if it detects that the built-in `npm`
+plugin has not been fully disabled.
+
+> [!IMPORTANT]
+> `"npm": false` is the only way to fully disable the built-in plugin. Setting
+> `npm: { publish: false }` is **not** sufficient — `release-it` will still run
+> `npm version` against the root package.
 
 ```json
 {
@@ -56,6 +63,13 @@ would add the following to your `release-it` config (again showing
   }
 }
 ```
+
+> [!NOTE]
+> When configuring via TypeScript with `satisfies Config`, `release-it`'s
+> exported `Config` type does not currently model the `npm: false` form, so
+> TypeScript will reject it even though it is valid at runtime. Use a type
+> assertion (e.g. `npm: false as never`) or configure via JSON/JS to work
+> around this.
 
 ## Configuration
 

--- a/index.js
+++ b/index.js
@@ -173,8 +173,6 @@ export default class WorkspacesPlugin extends Plugin {
       },
     });
 
-    this._warnIfBuiltinNpmEnabled();
-
     const { publishConfig, workspaces } = discoverWorkspaces();
 
     this.setContext({
@@ -202,6 +200,8 @@ export default class WorkspacesPlugin extends Plugin {
   }
 
   async init() {
+    this._warnIfBuiltinNpmEnabled();
+
     if (this.options.skipChecks) return;
 
     const validations = Promise.all([this.isRegistryUp(), this.isAuthenticated()]);

--- a/index.js
+++ b/index.js
@@ -173,6 +173,8 @@ export default class WorkspacesPlugin extends Plugin {
       },
     });
 
+    this._warnIfBuiltinNpmEnabled();
+
     const { publishConfig, workspaces } = discoverWorkspaces();
 
     this.setContext({
@@ -180,6 +182,23 @@ export default class WorkspacesPlugin extends Plugin {
       workspaces: this.options.workspaces || resolveWorkspaces(workspaces),
       root: process.cwd(),
     });
+  }
+
+  // This plugin fully replaces release-it's built-in `npm` plugin (it handles
+  // version bumping and publishing for each workspace). Leaving the built-in
+  // `npm` plugin enabled means release-it will _also_ run `npm version` and
+  // attempt to `npm publish` the root package, which conflicts with this
+  // plugin and produces confusing errors. The only way to fully disable it is
+  // `npm: false`; `npm: { publish: false }` is not enough (it still runs
+  // `npm version`). See https://github.com/release-it-plugins/workspaces/issues/125
+  // and https://github.com/release-it-plugins/workspaces/issues/132.
+  _warnIfBuiltinNpmEnabled() {
+    if (this.config.getContext('npm') !== false) {
+      this.log.warn(
+        `@release-it-plugins/workspaces replaces release-it's built-in \`npm\` plugin, but it is still enabled. ` +
+          `Add \`"npm": false\` to your release-it config to disable it (\`npm: { publish: false }\` is not sufficient).`
+      );
+    }
   }
 
   async init() {

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -17,14 +17,21 @@ class TestPlugin extends Plugin {
     this.prompts = [];
     this.logs = [];
   }
+
+  // warnings (e.g. invalid `npm` config detection) can be emitted during
+  // construction, before `buildPlugin` has a chance to swap out the log
+  // methods, so read them straight from the underlying `log.warn` mock
+  get warnings() {
+    return this.log.warn.mock.calls.map((call) => call.arguments);
+  }
 }
 
-async function buildPlugin(config = {}, _Plugin = TestPlugin) {
+async function buildPlugin(config = {}, _Plugin = TestPlugin, topLevelOptions = {}) {
   const container = {};
   const commandResponses = {};
   const promptResponses = {};
 
-  const options = { [namespace]: config };
+  const options = { ...topLevelOptions, [namespace]: config };
   const plugin = await factory(_Plugin, { container, namespace, options });
 
   plugin.log.log = (...args) => {
@@ -1409,6 +1416,44 @@ describe('@release-it-plugins/workspaces', () => {
           },
         ]
       `);
+    });
+  });
+
+  describe("detecting release-it's built-in `npm` plugin", () => {
+    beforeEach(() => {
+      setupProject(['packages/*']);
+      setupWorkspace({ name: 'foo' });
+      setupWorkspace({ name: 'bar' });
+    });
+
+    it('warns when the built-in `npm` plugin is left enabled (default config)', async () => {
+      let plugin = await buildPlugin();
+
+      expect(plugin.warnings).toMatchInlineSnapshot(`
+        [
+          [
+            "@release-it-plugins/workspaces replaces release-it's built-in \`npm\` plugin, but it is still enabled. Add \`"npm": false\` to your release-it config to disable it (\`npm: { publish: false }\` is not sufficient).",
+          ],
+        ]
+      `);
+    });
+
+    it('warns when the built-in `npm` plugin is only partially disabled with `npm: { publish: false }`', async () => {
+      let plugin = await buildPlugin({}, TestPlugin, { npm: { publish: false } });
+
+      expect(plugin.warnings).toMatchInlineSnapshot(`
+        [
+          [
+            "@release-it-plugins/workspaces replaces release-it's built-in \`npm\` plugin, but it is still enabled. Add \`"npm": false\` to your release-it config to disable it (\`npm: { publish: false }\` is not sufficient).",
+          ],
+        ]
+      `);
+    });
+
+    it('does not warn when the built-in `npm` plugin is fully disabled with `npm: false`', async () => {
+      let plugin = await buildPlugin({}, TestPlugin, { npm: false });
+
+      expect(plugin.warnings).toEqual([]);
     });
   });
 

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -16,13 +16,7 @@ class TestPlugin extends Plugin {
     this.commands = [];
     this.prompts = [];
     this.logs = [];
-  }
-
-  // warnings (e.g. invalid `npm` config detection) can be emitted during
-  // construction, before `buildPlugin` has a chance to swap out the log
-  // methods, so read them straight from the underlying `log.warn` mock
-  get warnings() {
-    return this.log.warn.mock.calls.map((call) => call.arguments);
+    this.warnings = [];
   }
 }
 
@@ -47,6 +41,9 @@ async function buildPlugin(config = {}, _Plugin = TestPlugin, topLevelOptions = 
       operationType: 'log.exec',
       messages: args,
     });
+  };
+  plugin.log.warn = (...args) => {
+    plugin.warnings.push(args);
   };
 
   plugin.commandResponses = commandResponses;
@@ -1427,7 +1424,9 @@ describe('@release-it-plugins/workspaces', () => {
     });
 
     it('warns when the built-in `npm` plugin is left enabled (default config)', async () => {
-      let plugin = await buildPlugin();
+      let plugin = await buildPlugin({ skipChecks: true });
+
+      await plugin.init();
 
       expect(plugin.warnings).toMatchInlineSnapshot(`
         [
@@ -1439,7 +1438,9 @@ describe('@release-it-plugins/workspaces', () => {
     });
 
     it('warns when the built-in `npm` plugin is only partially disabled with `npm: { publish: false }`', async () => {
-      let plugin = await buildPlugin({}, TestPlugin, { npm: { publish: false } });
+      let plugin = await buildPlugin({ skipChecks: true }, TestPlugin, { npm: { publish: false } });
+
+      await plugin.init();
 
       expect(plugin.warnings).toMatchInlineSnapshot(`
         [
@@ -1451,7 +1452,9 @@ describe('@release-it-plugins/workspaces', () => {
     });
 
     it('does not warn when the built-in `npm` plugin is fully disabled with `npm: false`', async () => {
-      let plugin = await buildPlugin({}, TestPlugin, { npm: false });
+      let plugin = await buildPlugin({ skipChecks: true }, TestPlugin, { npm: false });
+
+      await plugin.init();
 
       expect(plugin.warnings).toEqual([]);
     });


### PR DESCRIPTION
Closes #125
Closes #132

This plugin fully replaces release-it's built-in `npm` plugin. If the built-in plugin is left enabled, release-it *also* runs `npm version` and tries to publish the root package, producing confusing errors.

## Changes
- Detect the misconfiguration in the constructor and emit a clear, non-fatal warning whenever the built-in `npm` plugin is not fully disabled (i.e. `npm` is anything other than `false`). This is what #125 asked for.
- Document the correct configuration in the README, including the gotcha behind #132: `npm: false` is valid at runtime, but release-it's exported TypeScript `Config` type doesn't model the `false` form, so `satisfies Config` rejects it — a type assertion or JSON/JS config is needed.

## Note
Stacked on #126's replacement (the vitest 4 branch) because the new tests are authored against the vitest 4 harness. Base will auto-retarget to `master` once that merges.

`npm test` green: lint + 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)