### PR TITLE
Add publishPath option to publish a workspace from a subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,35 @@ This value replaces the value from `package.json`, and given the above
 configuration `@release-it-plugins/workspaces` would publish each package (that was
 not private) in `dist/packages` folder.
 
+### publishPath
+
+Unlike the options above, `publishPath` is not configured under the
+`@release-it-plugins/workspaces` plugin. Instead, it is set directly on an
+individual workspace's `package.json`. When present, that workspace is published
+from the specified subdirectory (relative to the package root) rather than from
+the package root itself.
+
+This is useful when a build step emits a ready-to-publish package into a
+subfolder (e.g. `dist`) and you only want the contents of that folder to be
+published:
+
+```json
+{
+  "name": "my-package",
+  "version": "1.0.0",
+  "publishPath": "dist"
+}
+```
+
+With this configuration, `@release-it-plugins/workspaces` runs the publish
+command from `my-package/dist` (e.g. `npm publish ./packages/my-package/dist`).
+
+Note that the version bump is still written to the workspace's own
+`package.json` (`my-package/package.json`), not to the `publishPath` directory.
+Your build step is responsible for ensuring the published folder contains an
+up-to-date `package.json` (most build tooling copies it into `dist` as part of
+the build).
+
 ### additionalManifests
 
 #### versionUpdates

--- a/index.js
+++ b/index.js
@@ -592,7 +592,7 @@ export default class WorkspacesPlugin extends Plugin {
       let absolutePath = path.join(root, file);
       let pkgInfo = JSONFile.for(absolutePath);
 
-      let relativeRoot = path.dirname(file);
+      let relativeRoot = path.join(path.dirname(file), pkgInfo.pkg.publishPath || '');
 
       return {
         root: path.join(root, relativeRoot),

--- a/tests/plugin-test.js
+++ b/tests/plugin-test.js
@@ -321,6 +321,33 @@ describe('@release-it-plugins/workspaces', () => {
       expect(readWorkspacePackage('foo').version).toEqual('1.0.1');
     });
 
+    it('publishes from the `publishPath` directory when specified', async () => {
+      setupProject(['packages/*']);
+
+      setupWorkspace({ name: 'foo' });
+      setupWorkspace({ name: 'bar', publishPath: 'dist' });
+
+      let plugin = await buildPlugin();
+
+      await runTasks(plugin);
+
+      let publishCommands = plugin.commands
+        .map((operation) => operation.command)
+        .filter((command) => command.startsWith('npm publish'));
+
+      expect(publishCommands).toMatchInlineSnapshot(`
+        [
+          "npm publish ./packages/bar/dist --tag latest",
+          "npm publish ./packages/foo --tag latest",
+        ]
+      `);
+
+      // the version bump is still written to the package's own package.json,
+      // not the publishPath directory
+      expect(readWorkspacePackage('bar').version).toEqual('1.0.1');
+      expect(readWorkspacePackage('foo').version).toEqual('1.0.1');
+    });
+
     it('works for pnpm', async () => {
       setupPnpmWorkspace(['packages/*']);
 


### PR DESCRIPTION
Reimplements and rebases #102 (original work by @thivi) onto current master.

## What it does
Adds an optional `publishPath` field on a workspace's own `package.json`. When set, that workspace publishes from the given subfolder — e.g. `"publishPath": "dist"` runs `npm publish ./packages/foo/dist` instead of `./packages/foo`. Useful when a build emits a ready-to-publish package into a subdirectory. It's the per-package analog of the existing project-wide `workspaces: ["dist/packages/*"]` option.

## Notes from the rebase
- The original 2023 diff targeted `findAdditionalManifests` (the version/dependency-update path); the publishing logic now lives in `getWorkspaces`, so the change was applied there. Confirmed against the PR's own expected output (`npm publish ./packages/bar/dist`).
- Tests rewritten for the current async harness.
- README documents that the version bump is written to the workspace's own `package.json`, so a "publish from dist" build must copy an up-to-date `package.json` into the publish dir.

Supersedes #102. `npm test` green: lint + 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)