### PR TITLE
Fix production security vulnerabilities (walk-sync, brace-expansion)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "semver": "^7.7.2",
         "url-join": "^4.0.1",
         "validate-peer-dependencies": "^1.2.0",
-        "walk-sync": "^2.2.0",
+        "walk-sync": "^4.0.2",
         "yaml": "^2.8.0"
       },
       "devDependencies": {
@@ -1994,9 +1994,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7205,6 +7205,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -11320,18 +11321,26 @@
       }
     },
     "node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-4.0.2.tgz",
+      "integrity": "sha512-SPRy/z6vC+Fb20XQDzagaSVVNzX77EcLLPnBJsqNy0CFQgBS6cexbYP62kzRSqNdyIDdRGc7SOCybRrpkf+Pmg==",
       "license": "MIT",
       "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
+        "ensure-posix-path": "^1.1.1",
+        "matcher-collection": "^2.0.1",
+        "minimatch": "^10.0.3"
       },
       "engines": {
-        "node": "8.* || >= 10.*"
+        "node": ">= 20.*"
+      }
+    },
+    "node_modules/walk-sync/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/walk-sync/node_modules/matcher-collection": {
@@ -11345,6 +11354,45 @@
       },
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/walk-sync/node_modules/matcher-collection/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/walk-sync/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/walk-sync/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "semver": "^7.7.2",
     "url-join": "^4.0.1",
     "validate-peer-dependencies": "^1.2.0",
-    "walk-sync": "^2.2.0",
+    "walk-sync": "^4.0.2",
     "yaml": "^2.8.0"
   },
   "devDependencies": {
@@ -49,6 +49,9 @@
   },
   "peerDependencies": {
     "release-it": "^17.0.0 || ^18.0.0 || ^19.0.0"
+  },
+  "overrides": {
+    "brace-expansion@<1.1.13": "^1.1.13"
   },
   "engines": {
     "node": "^20.9.0 || >=22.0.0"


### PR DESCRIPTION
`npm audit` flagged a **high** (minimatch ReDoS) and a **moderate** (brace-expansion ReDoS) in the **production** dependency tree — both reaching consumers via `walk-sync@2.2.0`, which pinned the old `minimatch@^3` line.

## Fix
- **`walk-sync` `^2.2.0` → `^4.0.2`** — walk-sync 4 uses `minimatch@^10` (patched), eliminating the ReDoS. Our usage (`walkSync(dir, { globs })`) is unchanged across the major; all 44 tests pass.
- **Override `brace-expansion@<1.1.13` → `^1.1.13`** — patches the vulnerable 1.x instances still pulled transitively (via `matcher-collection`'s minimatch@3), while leaving the modern 2.x+ line (used by minimatch@10) untouched.

## Result
**Production audit: 0 vulnerabilities.** Verified with `npm audit --omit=dev`.

The remaining 22 findings (incl. 8 high) are **all dev-only** — from `broccoli-test-helper` (test harness), `@release-it-plugins/lerna-changelog` (changelog), and `release-it` itself. None ship (this package publishes only `index.js`). Fully clearing them requires replacing `broccoli-test-helper` and/or `@release-it-plugins/lerna-changelog` (their vulns are either "no fix available" or need breaking downgrades) — proposed as a separate follow-up since it doesn't affect consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)